### PR TITLE
avoid using error message as granularity in message details

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,17 +68,26 @@ function _chaiMoment(chai, utils){
   });
 
   assert.sameMoment = function (val, exp, granularity, msg) {
-    if(!allowedGranularitiesLookup[granularity]) msg = granularity;
+    if(!allowedGranularitiesLookup[granularity]) {
+      msg = granularity;
+      granularity = undefined;
+    }
     new chai.Assertion(val, msg).to.be.sameMoment(exp, granularity);
   };
 
   assert.beforeMoment = function (val, exp, granularity, msg) {
-    if(!allowedGranularitiesLookup[granularity]) msg = granularity;
+    if(!allowedGranularitiesLookup[granularity]) {
+      msg = granularity;
+      granularity = undefined;
+    }
     new chai.Assertion(val, msg).to.be.beforeMoment(exp, granularity);
   };
 
   assert.afterMoment = function (val, exp, granularity, msg) {
-    if(!allowedGranularitiesLookup[granularity]) msg = granularity;
+    if(!allowedGranularitiesLookup[granularity]) {
+      msg = granularity;
+      granularity = undefined;
+    }
     new chai.Assertion(val, msg).to.be.afterMoment(exp, granularity);
   };
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -196,7 +196,7 @@ describe('beforeMoment', function() {
 
 describe('chaiMoment.setErrorFormat', function() {
   it('is a function', function() {
-    expect(chaiMoment.setErrorFormat).to.be.a.function;
+    expect(chaiMoment.setErrorFormat).to.be.a('function');
   });
 
   it('sets the moment.format() call for an error', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,7 @@ var chaiMoment = require('../index.js');
 
 chai.use(chaiMoment);
 
-chaiMoment.setErrorFormat('LLLL');
+chaiMoment.setErrorFormat('YYYYMMDDHHmmss');
 
 var moment = require('moment');
 
@@ -78,10 +78,16 @@ describe('sameMoment', function() {
       assert.sameMoment(date, oneDayLater, 'month');
     });
 
+    it('tdd-style with error message', function() {
+      assert.throws(function() {
+        assert.sameMoment(date, oneDayLater, 'day', 'not the same day');
+      }, /^not the same day: expected \d{14} to be the same as \d{14} \(granularity: day\)$/);
+    });
+
     it('tdd-style with error message in place of granularity should raise error', function() {
       assert.throws(function() {
         assert.sameMoment(date, oneDayLater, 'moments are not the same');
-      }, 'moments are not the same');
+      }, /^moments are not the same: expected \d{14} to be the same as \d{14}$/);
     });
 
   })
@@ -122,10 +128,16 @@ describe('afterMoment', function() {
       assert.afterMoment(oneYearLater, date, 'month');
     });
 
+    it('tdd-style with error message', function() {
+      assert.throws(function() {
+        assert.afterMoment(date, obj, 'second', 'not after second granularity');
+      }, /^not after second granularity: expected \d{14} to be after \d{14} \(granularity: second\)$/);
+    });
+
     it('tdd-style with error message in place of granularity should raise error', function() {
       assert.throws(function() {
         assert.afterMoment(date, obj, 'moment is not after expected');
-      }, 'moment is not after expected');
+      }, /^moment is not after expected: expected \d{14} to be after \d{14}$/);
     });
 
   });
@@ -168,8 +180,14 @@ describe('beforeMoment', function() {
 
     it('tdd-style with error message in place of granularity should raise error', function() {
       assert.throws(function() {
+        assert.beforeMoment(date, obj, 'second', 'not before second granularity');
+      }, /^not before second granularity: expected \d{14} to be before \d{14} \(granularity: second\)$/);
+    });
+
+    it('tdd-style with error message in place of granularity should raise error', function() {
+      assert.throws(function() {
         assert.beforeMoment(date, obj, 'moment is not before expected');
-      }, 'moment is not before expected');
+      }, /^moment is not before expected: expected \d{14} to be before \d{14}$/);
     });
 
   });


### PR DESCRIPTION
When using the assert interface, putting the error message in the granularity parameter's position will get us something like:
`assert.sameMoment(a, b, "error message");`

`error message: expect a to be the same as b (granularity: error message)`

The granularity should be skipped since it's not provided at all. And we shouldn't be taking the error message as granularity either.